### PR TITLE
Adds simulated LiDAR scan for SLAM

### DIFF
--- a/include/occupancy_maze_simulator/occupancy_maze_simulator.hpp
+++ b/include/occupancy_maze_simulator/occupancy_maze_simulator.hpp
@@ -43,6 +43,8 @@ private:
     const std::vector<Obstacle> & obstacles, const std::pair<int, int> & area_size,
     float cell_size);
 
+  nav_msgs::msg::OccupancyGrid create_empty_grid_map();
+
   void twist_callback(geometry_msgs::msg::Twist::SharedPtr msg);
 
   static std::vector<Obstacle> generate_random_obstacles(
@@ -66,8 +68,13 @@ private:
 
   void publish_gridmap();
 
+  void publish_slam_gridmap();
+
+  void simulate_lidar_scan();
+
   rclcpp::TimerBase::SharedPtr publish_pose_timer_;
   rclcpp::TimerBase::SharedPtr publish_gridmap_timer_;
+  rclcpp::TimerBase::SharedPtr publish_slam_gridmap_timer_;
   rclcpp::Time last_update_time_;
 
   double yaw_;
@@ -83,11 +90,13 @@ private:
   float cell_size_;
   float maze_density_;
   nav_msgs::msg::OccupancyGrid grid_map_;
+  nav_msgs::msg::OccupancyGrid slam_grid_map_;
 
   tf2_ros::Buffer tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr occupancy_grid_publisher_;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr slam_grid_publisher_;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_publisher_;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr goal_publisher_;
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_subscriber_;

--- a/include/occupancy_maze_simulator/occupancy_maze_simulator.hpp
+++ b/include/occupancy_maze_simulator/occupancy_maze_simulator.hpp
@@ -77,11 +77,11 @@ private:
   rclcpp::TimerBase::SharedPtr publish_slam_gridmap_timer_;
   rclcpp::Time last_update_time_;
 
-  double yaw_ = 0.0F;
-  double robot_x_ = 0.0F;
-  double robot_y_ = 0.0F;
-  double current_linear_velocity_ = 0.0F;
-  double current_angular_velocity_ = 0.0F;
+  double yaw_ = 0.0;
+  double robot_x_ = 0.0;
+  double robot_y_ = 0.0;
+  double current_linear_velocity_ = 0.0;
+  double current_angular_velocity_ = 0.0;
 
   int num_cells_x_;
   int num_cells_y_;

--- a/include/occupancy_maze_simulator/occupancy_maze_simulator.hpp
+++ b/include/occupancy_maze_simulator/occupancy_maze_simulator.hpp
@@ -77,11 +77,11 @@ private:
   rclcpp::TimerBase::SharedPtr publish_slam_gridmap_timer_;
   rclcpp::Time last_update_time_;
 
-  double yaw_;
-  double robot_x_;
-  double robot_y_;
-  double current_linear_velocity_;
-  double current_angular_velocity_;
+  double yaw_ = 0.0F;
+  double robot_x_ = 0.0F;
+  double robot_y_ = 0.0F;
+  double current_linear_velocity_ = 0.0F;
+  double current_angular_velocity_ = 0.0F;
 
   int num_cells_x_;
   int num_cells_y_;

--- a/rviz/config.rviz
+++ b/rviz/config.rviz
@@ -7,6 +7,7 @@ Panels:
         - /Global Options1
         - /Status1
         - /Grid1
+        - /Obstacle's Occupancy Grid Map1
         - /Axes1
         - /Pose1
         - /Pose2
@@ -15,6 +16,7 @@ Panels:
         - /Centroids1
         - /Intersections1
         - /Rotational Force1
+        - /slam_gridmap1
       Splitter Ratio: 0.5
     Tree Height: 508
   - Class: rviz_common/Selection
@@ -56,7 +58,7 @@ Visualization Manager:
       Plane Cell Count: 10
       Reference Frame: <Fixed Frame>
       Value: true
-    - Alpha: 0.699999988079071
+    - Alpha: 0.5
       Class: rviz_default_plugins/Map
       Color Scheme: map
       Draw Behind: false
@@ -230,10 +232,10 @@ Visualization Manager:
       Value: true
     - Alpha: 0.699999988079071
       Class: rviz_default_plugins/Map
-      Color Scheme: map
+      Color Scheme: costmap
       Draw Behind: false
       Enabled: true
-      Name: Map
+      Name: slam_gridmap
       Topic:
         Depth: 5
         Durability Policy: Volatile
@@ -295,7 +297,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 100.07605743408203
+      Distance: 77.4989013671875
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
@@ -310,10 +312,10 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 1.5647963285446167
+      Pitch: 0.814797043800354
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 4.258583068847656
+      Yaw: 3.9135806560516357
     Saved: ~
 Window Geometry:
   Displays:

--- a/rviz/config.rviz
+++ b/rviz/config.rviz
@@ -7,14 +7,16 @@ Panels:
         - /Global Options1
         - /Status1
         - /Grid1
-        - /Map1
-        - /Map1/Status1
         - /Axes1
         - /Pose1
         - /Pose2
         - /Pose3
+        - /Marker1
+        - /Centroids1
+        - /Intersections1
+        - /Rotational Force1
       Splitter Ratio: 0.5
-    Tree Height: 1087
+    Tree Height: 508
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -112,7 +114,7 @@ Visualization Manager:
       Head Radius: 0.10000000149011612
       Name: Pose
       Shaft Length: 1
-      Shaft Radius: 5
+      Shaft Radius: 1
       Shape: Arrow
       Topic:
         Depth: 5
@@ -146,7 +148,7 @@ Visualization Manager:
       Class: rviz_default_plugins/Map
       Color Scheme: map
       Draw Behind: false
-      Enabled: true
+      Enabled: false
       Name: Current Robot Position Map
       Topic:
         Depth: 5
@@ -161,6 +163,90 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /current_robot_position_gridmap_updates
+      Use Timestamp: false
+      Value: false
+    - Class: rviz_default_plugins/Marker
+      Enabled: true
+      Name: Marker
+      Namespaces:
+        combined_contours: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /contours_marker
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /contours_image
+      Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: Centroids
+      Namespaces:
+        centroid: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /centroids_marker
+      Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: Intersections
+      Namespaces:
+        {}
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /intersections_marker
+      Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: Rotational Force
+      Namespaces:
+        {}
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /rotational_force_marker
+      Value: true
+    - Alpha: 0.699999988079071
+      Class: rviz_default_plugins/Map
+      Color Scheme: map
+      Draw Behind: false
+      Enabled: true
+      Name: Map
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /slam_gridmap
+      Update Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /slam_gridmap_updates
       Use Timestamp: false
       Value: true
   Enabled: true
@@ -209,33 +295,35 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 49.8631477355957
+      Distance: 100.07605743408203
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 17.528560638427734
-        Y: 13.658605575561523
-        Z: 5.202381610870361
+        X: 31.463550567626953
+        Y: 23.098318099975586
+        Z: -5.350255966186523
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.7803981304168701
+      Pitch: 1.5647963285446167
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 4.0685858726501465
+      Yaw: 4.258583068847656
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1501
+  Height: 1031
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd000000040000000000000247000004f9fc020000000efb0000001200530065006c0065006300740069006f006e00000001e10000009b0000007a01000003fb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000005a000000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000005a000004f90000010701000003fb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d00650072006100000002ad0000010a0000000000000000fb0000000a0049006d00610067006501000002b0000000a40000000000000000fb0000000a0049006d0061006700650100000355000001fe0000000000000000fb0000000a0049006d006100670065000000034c0000010a0000000000000000fb0000000a0049006d0061006700650000000414000000c80000000000000000fb0000000c00430061006d00650072006100000004c70000008c00000000000000000000000100000111000004f9fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000005a000004f9000000e601000003fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000a0000000056fc0100000002fb0000000800540069006d0065010000000000000a000000039101000003fb0000000800540069006d00650100000000000004500000000000000000000006a6000004f900000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Image:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000024700000323fc020000000ffb0000001200530065006c0065006300740069006f006e00000001e10000009b0000007a01000003fb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed0000059d00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000005a000002b60000010701000003fb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d00650072006100000002ad0000010a0000000000000000fb0000000a0049006d00610067006501000003110000006c0000002f01000003fb0000000a0049006d0061006700650100000355000001fe0000000000000000fb0000000a0049006d006100670065000000034c0000010a0000000000000000fb0000000a0049006d0061006700650000000414000000c80000000000000000fb0000000c00430061006d00650072006100000004c70000008c0000000000000000fb0000000a0049006d0061006700650100000472000000e10000000000000000000000010000011100000323fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000005a00000323000000e601000003fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000078000000056fc0100000002fb0000000800540069006d00650100000000000007800000039101000003fb0000000800540069006d00650100000000000004500000000000000000000004260000032300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -244,6 +332,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 2560
-  X: 1
-  Y: 1080
+  Width: 1920
+  X: 296
+  Y: 0

--- a/src/occupancy_maze_simulator.cpp
+++ b/src/occupancy_maze_simulator.cpp
@@ -53,6 +53,7 @@ OccupancyMazeSimulator::OccupancyMazeSimulator(const rclcpp::NodeOptions & optio
   }
 
   occupancy_grid_publisher_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>("gridmap", 10);
+  slam_grid_publisher_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>("slam_gridmap", 10);
   pose_publisher_ = this->create_publisher<geometry_msgs::msg::PoseStamped>("glim_ros/pose", 10);
   goal_publisher_ = this->create_publisher<geometry_msgs::msg::PoseStamped>("goal_position", 10);
 
@@ -93,6 +94,11 @@ OccupancyMazeSimulator::OccupancyMazeSimulator(const rclcpp::NodeOptions & optio
       std::chrono::seconds(1), std::bind(&OccupancyMazeSimulator::publish_gridmap, this));
   }
   last_update_time_ = rclcpp::Clock(RCL_STEADY_TIME).now();
+
+  slam_grid_map_ = create_empty_grid_map();
+
+  publish_slam_gridmap_timer_ = this->create_wall_timer(
+    std::chrono::milliseconds(100), std::bind(&OccupancyMazeSimulator::publish_slam_gridmap, this));
 }
 
 nav_msgs::msg::OccupancyGrid OccupancyMazeSimulator::create_grid_map(
@@ -120,6 +126,21 @@ nav_msgs::msg::OccupancyGrid OccupancyMazeSimulator::create_grid_map(
       RCLCPP_WARN(this->get_logger(), "Obstacle out of grid bounds at (%d, %d)", cell_x, cell_y);
     }
   }
+  return grid_msg;
+}
+
+nav_msgs::msg::OccupancyGrid OccupancyMazeSimulator::create_empty_grid_map(){
+  nav_msgs::msg::OccupancyGrid grid_msg;
+  grid_msg.info.resolution = cell_size_;
+  grid_msg.info.origin.orientation.w = 1.0;
+  grid_msg.info.width = num_cells_x_;
+  grid_msg.info.height = num_cells_y_;
+  grid_msg.info.origin.position.x = 0.0;
+  grid_msg.info.origin.position.y = 0.0;
+  grid_msg.data.resize(num_cells_x_ * num_cells_y_, 0);  // 0で初期化
+  grid_msg.header.frame_id = "odom";
+  grid_msg.header.stamp = this->get_clock()->now();
+
   return grid_msg;
 }
 
@@ -280,6 +301,49 @@ void OccupancyMazeSimulator::simulate_robot_position(geometry_msgs::msg::Twist::
   robot_x_ += delta_x;
   robot_y_ += delta_y;
   yaw_ += delta_yaw;
+}
+
+void OccupancyMazeSimulator::simulate_lidar_scan()
+{
+  const int num_lidar_rays = 360;       // 360本のレーザー
+  const double max_lidar_range = 10.0;  // LiDARの最大範囲 (メートル)
+  const double angle_increment = 2 * M_PI / num_lidar_rays;
+
+  for (int i = 0; i < num_lidar_rays; ++i) {
+    double angle = i * angle_increment + yaw_;
+    double cos_a = std::cos(angle);
+    double sin_a = std::sin(angle);
+
+    for (double r = 0.0; r <= max_lidar_range; r += cell_size_) {
+      double x = robot_x_ + r * cos_a;
+      double y = robot_y_ + r * sin_a;
+
+      int cell_x = static_cast<int>(std::round(x / cell_size_));
+      int cell_y = static_cast<int>(std::round(y / cell_size_));
+
+      // グリッド範囲外なら終了
+      if (cell_x < 0 || cell_x >= num_cells_x_ || cell_y < 0 || cell_y >= num_cells_y_) {
+        break;
+      }
+
+      int index = cell_y * num_cells_x_ + cell_x;
+
+      // 障害物セルに到達したら終了
+      if (grid_map_.data[index] == 100) {
+        slam_grid_map_.data[index] = 100;  // 障害物としてマーク
+        break;
+      }
+
+      slam_grid_map_.data[index] = 0;
+    }
+  }
+}
+
+void OccupancyMazeSimulator::publish_slam_gridmap()
+{
+  simulate_lidar_scan();
+  slam_grid_map_.header.stamp = this->get_clock()->now();
+  slam_grid_publisher_->publish(slam_grid_map_);
 }
 
 // Alt option for robot position simulation Not TESTED, so comment out for now


### PR DESCRIPTION
Implements a simulated LiDAR scan within the occupancy maze simulator.  This scan updates a separate `slam_grid_map` based on the current robot pose and the environment obstacles.  The `slam_grid_map` is published for visualization and use within SLAM algorithms.

The visualization in RViz is also updated to display the new `slam_grid_map` and to hide the original, complete `grid_map`.  Several new display panels are added to visualize additional data relevant to the SLAM implementation.

closes #3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 空の占有グリッドマップを作成する機能を追加。
  - LIDARスキャンをシミュレートする新しい機能を追加。
  - SLAMグリッドマップを定期的に公開する機能を追加。
  - RVizに新しい視覚化クラス（マーカー、画像、重心、交差点、回転力）を追加。

- **設定変更**
  - RVizの表示要素のレイアウトとプロパティを変更。
  - 表示要素のコンパクト化を図るため、ツリーハイトを調整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->