### PR TITLE
20 get target and start position from global planner

### DIFF
--- a/occupancy_maze_simulator/include/occupancy_maze_simulator/occupancy_maze_simulator.hpp
+++ b/occupancy_maze_simulator/include/occupancy_maze_simulator/occupancy_maze_simulator.hpp
@@ -88,6 +88,8 @@ private:
 
   void selected_gridmap_callback(nav_msgs::msg::OccupancyGrid::SharedPtr msg);
 
+  void wait_for_messages();
+
   rclcpp::TimerBase::SharedPtr publish_pose_timer_;
   rclcpp::TimerBase::SharedPtr publish_gridmap_timer_;
   rclcpp::TimerBase::SharedPtr publish_slam_gridmap_timer_;
@@ -95,10 +97,12 @@ private:
 
   geometry_msgs::msg::PoseStamped start_pose_;
   geometry_msgs::msg::PoseStamped target_pose_;
+  bool start_pose_received_ = false;
+  bool target_pose_received_ = false;
 
   double yaw_ = 0.0;
-  double robot_x_ = 0.0;
-  double robot_y_ = 0.0;
+  double robot_x_ = -20.0;
+  double robot_y_ = -20.0;
   double current_linear_velocity_ = 0.0;
   double current_angular_velocity_ = 0.0;
 
@@ -139,8 +143,6 @@ private:
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr slam_grid_publisher_;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_publisher_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr text_marker_publisher_;
-  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr start_pose_publisher_;
-  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr target_pose_publisher_;
   rclcpp::Publisher<std_msgs::msg::Empty>::SharedPtr reset_publisher_;
   rclcpp::Publisher<std_msgs::msg::Empty>::SharedPtr emergency_stop_publisher_;
   rclcpp::Client<nav2_msgs::srv::LoadMap>::SharedPtr load_map_client_;
@@ -148,6 +150,8 @@ private:
   rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr reset_subscriber_;
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr failed_subscriber_;
   rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr selected_gridmap_subscriber_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr start_pose_subscriber_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr target_pose_subscriber_;
 };
 
 }  // namespace occupancy_maze_simulator

--- a/occupancy_maze_simulator/launch/fast_simulation_launch.py
+++ b/occupancy_maze_simulator/launch/fast_simulation_launch.py
@@ -82,6 +82,21 @@ def generate_launch_description():
         namespace=namespace,
     )
 
+    global_planner_node = Node(
+        package="path_planner",
+        executable="global_planner_node",
+        output="screen",
+        parameters=[
+            {
+                "mode": "static",
+                "pose_topic": "mavros/vision_pose/pose",
+                "goal_reached_tolerance": 1.0,
+            }
+        ],
+        arguments=["--ros-args", "--log-level", "info"],
+        namespace=namespace,
+    )
+
     rviz_config_path = os.path.join(
         occupancy_maze_simulator_dir, 'rviz', 'config.rviz')
 
@@ -100,6 +115,7 @@ def generate_launch_description():
 
     ld.add_action(omc_node)
     ld.add_action(path_planner_node)
+    ld.add_action(global_planner_node)
     ld.add_action(rviz)
     ld.add_action(
         ExecuteProcess(

--- a/occupancy_maze_simulator/launch/simulation_with_selected_gridmap_launch.py
+++ b/occupancy_maze_simulator/launch/simulation_with_selected_gridmap_launch.py
@@ -100,6 +100,21 @@ def generate_launch_description(namespace: str = 'drone1'):
         namespace=namespace,
     )
 
+    global_planner_node = Node(
+        package="path_planner",
+        executable="global_planner_node",
+        output="screen",
+        parameters=[
+            {
+                "mode": "static",
+                "pose_topic": "mavros/vision_pose/pose",
+                "goal_reached_tolerance": 1.0,
+            }
+        ],
+        arguments=["--ros-args", "--log-level", "info"],
+        namespace=namespace,
+    )
+
     omc_share_directory = get_package_share_directory(
         'occupancy_maze_simulator')
     rviz_config_path = os.path.join(
@@ -147,6 +162,7 @@ def generate_launch_description(namespace: str = 'drone1'):
         )
     )
     ld.add_action(path_planner_node)
+    ld.add_action(global_planner_node)
     ld.add_action(rviz)
     ld.add_action(
         ExecuteProcess(


### PR DESCRIPTION
closes #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

リリースノート:

- **新機能**
  - グリッドマップでのマウスドラッグによるセル選択が可能になりました
  - シミュレーションに新しいグローバルプランナーノードを追加

- **改善点**
  - ロボットの初期位置設定方法を変更
  - ポーズ管理のメッセージング方式を更新

- **その他の変更**
  - シミュレーション起動設定を最適化
  - メッセージ待機メカニズムを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->